### PR TITLE
Update acf_admin_columns.php

### DIFF
--- a/acf_admin_columns.php
+++ b/acf_admin_columns.php
@@ -317,9 +317,12 @@ class FleiACFAdminColumns
                         $p = $field_value[0];
                         $items_more = count($field_value) - 1;
                     }
-                    if (is_object($p)) {
-                        $render_output = '<a href="' . get_edit_post_link($p, false) . '">' . $p->post_title . '</a>';
+                    
+                    if (!empty($p)) {
+                        $render_output = '<a href="' . get_edit_post_link($p, false) . '">' . get_the_title($p) . '</a>';
                     }
+                    
+                    
 
                     break;
                 case 'user':


### PR DESCRIPTION
When the field is of type  'post_object' or 'relationship' we can have two cases (render as object or render as id). We can manage both cases by using get_the_title and testing for is empty instead of is_object.